### PR TITLE
[Editorial] "ultimo" -> "inst."

### DIFF
--- a/src/epub/text/chapter-1.xhtml
+++ b/src/epub/text/chapter-1.xhtml
@@ -61,7 +61,7 @@
 				<header>
 					<p epub:type="se:letter.dateline">“Baltimore, <time datetime="10-03">October 3rd</time></p>
 				</header>
-				<p>“The president of the Gun Club has the honour to inform his colleagues that at the meeting on the 5th ultimo he will make them a communication of an extremely interesting nature. He therefore begs that they, to the suspension of all other business, will attend, in accordance with the present invitation,</p>
+				<p>“The president of the Gun Club has the honour to inform his colleagues that at the meeting on the 5th <abbr>inst.</abbr> he will make them a communication of an extremely interesting nature. He therefore begs that they, to the suspension of all other business, will attend, in accordance with the present invitation,</p>
 				<footer>
 					<p epub:type="z3998:valediction">“Their devoted colleague,</p>
 					<p epub:type="z3998:sender z3998:signature">“Impey Barbicane, <abbr class="eoc" epub:type="z3998:given-name">P. G. C.</abbr>”</p>


### PR DESCRIPTION
It makes no sense to talk of a *coming* announcement to be expected in the *previous* month's meeting. Going back to the French version at https://gutenberg.org/cache/epub/38674/pg38674.txt it speaks of "la séance du 5 courant" instead, which makes a lot more sense.